### PR TITLE
ConCat hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+.direnv

--- a/cabal.project
+++ b/cabal.project
@@ -63,6 +63,7 @@ packages:
   ./plugin/categorifier-plugin.cabal
   ./plugin-test/categorifier-plugin-test.cabal
   ./th/categorifier-th.cabal
+  ./examples/examples.cabal
 -- __TODO__: Uncomment below once Cabal 3.8 is released.
 -- if impl(ghc >= 9.0.0)
 --   packages:

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -22,11 +22,18 @@ executable simple
       -fno-omit-interface-pragmas
       -Wall
       -fplugin Categorifier
+      -fplugin Categorifier
+      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.UnconCat.hierarchy
+      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
+      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
   build-depends:
       base
     , categorifier-plugin
     , categorifier-category
     , categorifier-client
+    , categorifier-unconcat-integration
+    , categorifier-concat-integration
+    , categorifier-concat-extensions-integration
     , concat-classes
     , constraints
     , ghc-prim

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -1,0 +1,40 @@
+cabal-version:  2.4
+
+name:           examples
+version:        0.1
+homepage:       https://github.com/con-kitty/categorifier-c#readme
+bug-reports:    https://github.com/con-kitty/categorifier-c/issues
+build-type:     Simple
+tested-with:    GHC==8.10.1, GHC==8.10.2, GHC==8.10.4, GHC==8.10.7, GHC==9.0.1, GHC==9.0.2
+
+source-repository head
+  type: git
+  location: https://github.com/con-kitty/categorifier-c
+
+executable simple
+  hs-source-dirs: simple
+  main-is: Main.hs
+  ghc-options:
+      -O0
+      -fexpose-all-unfoldings
+      -fmax-simplifier-iterations=0
+      -fno-ignore-interface-pragmas
+      -fno-omit-interface-pragmas
+      -Wall
+      -fplugin Categorifier
+      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.UnconCat.hierarchy
+      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
+      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
+  build-depends:
+      base
+    , ghc-prim
+    , concat-classes
+    , categorifier-category
+    , categorifier-client
+    , categorifier-concat-extensions-category
+    , categorifier-concat-extensions-integration
+    , categorifier-concat-integration
+    , categorifier-plugin
+    , categorifier-unconcat-category
+    , categorifier-unconcat-integration
+  default-language: Haskell2010

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -22,19 +22,13 @@ executable simple
       -fno-omit-interface-pragmas
       -Wall
       -fplugin Categorifier
-      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.UnconCat.hierarchy
-      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
-      -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
   build-depends:
       base
-    , ghc-prim
-    , concat-classes
+    , categorifier-plugin
     , categorifier-category
     , categorifier-client
-    , categorifier-concat-extensions-category
-    , categorifier-concat-extensions-integration
-    , categorifier-concat-integration
-    , categorifier-plugin
-    , categorifier-unconcat-category
-    , categorifier-unconcat-integration
+    , concat-classes
+    , constraints
+    , ghc-prim
+    , mtl
   default-language: Haskell2010

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -1,4 +1,125 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Main where
 
-main :: IO Int
-main = putStrLn "Hello, Haskell!"
+import qualified Categorifier.Categorify as Categorify
+import Categorifier.Client (deriveHasRep)
+import qualified ConCat.Category as ConCat
+import qualified Control.Arrow as Base
+import Control.Monad ((<=<))
+import Control.Monad.State (State, runState)
+import Control.Monad.State.Class (get, modify, put)
+import Data.Constraint
+import Data.Kind (Type)
+
+type Port = Int
+
+genPort :: GraphM Port
+genPort = do
+  (o, comps) <- get
+  put (o + 1, comps)
+  pure o
+
+data Ports :: Type -> Type where
+  UnitP :: Ports ()
+  BoolP :: Port -> Ports Bool
+  IntP :: Port -> Ports Int
+  PairP :: Ports a -> Ports b -> Ports (a, b)
+  FunP :: Graph a b -> Ports (a -> b)
+
+class GenPorts a where
+  genPorts :: GraphM (Ports a)
+
+instance GenPorts () where
+  genPorts = pure UnitP
+
+instance GenPorts Bool where
+  genPorts = BoolP <$> genPort
+
+instance GenPorts Int where
+  genPorts = IntP <$> genPort
+
+instance (GenPorts a, GenPorts b) => GenPorts (a, b) where
+  genPorts = PairP <$> genPorts <*> genPorts
+
+--instance (GenPorts a, GenPorts b) => GenPorts (a -> b) where
+--  genPorts = do
+--    a <- genPorts
+--    b <- genPorts
+--    pure $ FunP (Graph (Kleisli $ \x -> pure (runGraph a x, runGraph b x)))
+
+data Comp where
+  Comp :: forall a b. String -> (Ports a) -> (Ports b) -> Comp
+
+genComp :: GenPorts b => String -> Graph a b
+genComp name = Graph $ \a -> do
+  b <- genPorts
+  modify (Base.second (Comp name a b :))
+  pure b
+
+type GraphM = State (Port, [Comp])
+
+data Graph a b = Graph {runGraph :: Ports a -> GraphM (Ports b)}
+{-# ANN Graph "Hlint: ignore Use newtype instead of data" #-}
+
+deriveHasRep ''Graph
+
+instance ConCat.Category Graph where
+  --  type Ok Graph = GenPorts
+  id = Graph pure
+  Graph f . Graph g = Graph (f <=< g)
+
+instance ConCat.ProductCat Graph where
+  exl = Graph $ \(PairP a _) -> pure a
+  exr = Graph $ \(PairP _ b) -> pure b
+  dup = Graph $ \a -> pure (PairP a a)
+
+instance ConCat.TerminalCat Graph where
+  it = Graph $ \UnitP -> pure UnitP
+
+instance ConCat.OpCon (ConCat.Prod Graph) (ConCat.Sat GenPorts) where inOp = ConCat.Entail (Sub Dict)
+
+--instance ConCat.OpCon (ConCat.Exp Graph) (ConCat.Sat GenPorts) where inOp = ConCat.Entail (Sub Dict)
+
+instance ConCat.ClosedCat Graph where
+  curry :: Graph (a, b) c -> Graph a (b -> c)
+  curry (Graph f) = Graph $ \a ->
+    pure $
+      FunP $
+        Graph $
+          \b ->
+            f (PairP a b)
+
+  uncurry :: Graph a (b -> c) -> Graph (a, b) c
+  uncurry (Graph f) = Graph $
+    \(PairP a b) -> do
+      x <- f a
+      case x of
+        FunP (Graph g) -> g b
+
+instance (Num a, GenPorts a) => ConCat.NumCat Graph a where
+  negateC = genComp "negate"
+  addC = genComp "+"
+  subC = genComp "-"
+  mulC = genComp "×"
+  powIC = genComp "^"
+
+square :: Int -> Int
+square a = a * a
+
+program :: Graph Int Int
+program = Categorify.expression square
+
+main :: IO ()
+main = print $ case runState (runGraph program (IntP 5)) (1, []) of
+  (IntP a, _) -> a

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO Int
+main = putStrLn "Hello, Haskell!"

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,133 @@
+cradle:
+  cabal:
+    - path: "./category/./"
+      component: "lib:categorifier-category"
+
+    - path: "./client/./"
+      component: "lib:categorifier-client"
+
+    - path: "./client/test"
+      component: "categorifier-client:test:client-instances"
+
+    - path: "./common/./"
+      component: "lib:categorifier-common"
+
+    - path: "./duoids/./"
+      component: "lib:categorifier-duoids"
+
+    - path: "./examples/simple/Main.hs"
+      component: "examples:exe:simple"
+
+    - path: "./ghc/./"
+      component: "lib:categorifier-ghc"
+
+    - path: "./hedgehog/./"
+      component: "lib:categorifier-hedgehog"
+
+    - path: "./integrations/adjunctions/integration/./"
+      component: "lib:categorifier-adjunctions-integration"
+
+    - path: "./integrations/adjunctions/integration-test/./"
+      component: "lib:categorifier-adjunctions-integration-test"
+
+    - path: "./integrations/adjunctions/integration-test/test"
+      component: "categorifier-adjunctions-integration-test:test:adjunctions-hierarchy"
+
+    - path: "./integrations/adjunctions/integration-test/test"
+      component: "categorifier-adjunctions-integration-test:test:adjunctions-hierarchy-optimized"
+
+    - path: "./integrations/categories/integration/./"
+      component: "lib:categorifier-categories-integration"
+
+    - path: "./integrations/categories/integration-test/./"
+      component: "lib:categorifier-categories-integration-test"
+
+    - path: "./integrations/categories/integration-test/test"
+      component: "categorifier-categories-integration-test:test:categories-hierarchy"
+
+    - path: "./integrations/categories/integration-test/test"
+      component: "categorifier-categories-integration-test:test:categories-hierarchy-optimized"
+
+    - path: "./integrations/concat/examples/./"
+      component: "lib:categorifier-concat-examples"
+
+    - path: "./integrations/concat/integration/./"
+      component: "lib:categorifier-concat-integration"
+
+    - path: "./integrations/concat/integration-test/./"
+      component: "lib:categorifier-concat-integration-test"
+
+    - path: "./integrations/concat/integration-test/test"
+      component: "categorifier-concat-integration-test:test:concat-class-hierarchy"
+
+    - path: "./integrations/concat/integration-test/test"
+      component: "categorifier-concat-integration-test:test:concat-class-hierarchy-optimized"
+
+    - path: "./integrations/concat/integration-test/test"
+      component: "categorifier-concat-integration-test:test:concat-function-hierarchy"
+
+    - path: "./integrations/concat/integration-test/test"
+      component: "categorifier-concat-integration-test:test:concat-function-hierarchy-optimized"
+
+    - path: "./integrations/concat-extensions/category/./"
+      component: "lib:categorifier-concat-extensions-category"
+
+    - path: "./integrations/concat-extensions/integration/./"
+      component: "lib:categorifier-concat-extensions-integration"
+
+    - path: "./integrations/concat-extensions/integration-test/./"
+      component: "lib:categorifier-concat-extensions-integration-test"
+
+    - path: "./integrations/concat-extensions/integration-test/test"
+      component: "categorifier-concat-extensions-integration-test:test:concat-extensions-hierarchy"
+
+    - path: "./integrations/concat-extensions/integration-test/test"
+      component: "categorifier-concat-extensions-integration-test:test:concat-extensions-hierarchy-optimized"
+
+    - path: "./integrations/fin/integration/./"
+      component: "lib:categorifier-fin-integration"
+
+    - path: "./integrations/unconcat/category/./"
+      component: "lib:categorifier-unconcat-category"
+
+    - path: "./integrations/unconcat/integration/./"
+      component: "lib:categorifier-unconcat-integration"
+
+    - path: "./integrations/unconcat/integration-test/./"
+      component: "lib:categorifier-unconcat-integration-test"
+
+    - path: "./integrations/unconcat/integration-test/test"
+      component: "categorifier-unconcat-integration-test:test:unconcat-hierarchy"
+
+    - path: "./integrations/unconcat/integration-test/test"
+      component: "categorifier-unconcat-integration-test:test:unconcat-hierarchy-optimized"
+
+    - path: "./integrations/vec/integration/./"
+      component: "lib:categorifier-vec-integration"
+
+    - path: "./integrations/vec/integration-test/./"
+      component: "lib:categorifier-vec-integration-test"
+
+    - path: "./integrations/vec/integration-test/test"
+      component: "categorifier-vec-integration-test:test:vec-hierarchy"
+
+    - path: "./integrations/vec/integration-test/test"
+      component: "categorifier-vec-integration-test:test:vec-hierarchy-optimized"
+
+    - path: "./plugin/./"
+      component: "lib:categorifier-plugin"
+
+    - path: "./plugin-test/./"
+      component: "lib:categorifier-plugin-test"
+
+    - path: "./plugin-test/test"
+      component: "categorifier-plugin-test:test:default-plugin"
+
+    - path: "./plugin-test/test"
+      component: "categorifier-plugin-test:test:base-hierarchy"
+
+    - path: "./plugin-test/test"
+      component: "categorifier-plugin-test:test:base-hierarchy-optimized"
+
+    - path: "./th/./"
+      component: "lib:categorifier-th"


### PR DESCRIPTION
currently fails with

```
1 of 1] Compiling Main             ( simple/Main.hs, /home/martin/code/haskell/categorifier/dist-newstyle/build/x86_64-linux/ghc-9.0.1/examples-0.1/x/simple/build/simple/simple-tmp/Main.o, /home/martin/code/haskell/categorifier/dist-newstyle/build/x86_64-linux/ghc-9.0.1/examples-0.1/x/simple/build/simple/simple-tmp/Main.dyn_o )
ghc: panic! (the 'impossible' happened)
  (GHC version 9.0.1:
Categorifier failed to categorify the following expression:
square
  - couldn't build dictionary for constraint

AssociativePCat Graph

required by lassocP @Graph.
    - If the following errors refer to a missing instance (particularly for
     `HasRep`), it's likely that you need to define it.
      - <interactive>:1:1: error:
      No instance for (categorifier-unconcat-category-0.1:Categorifier.UnconCat.AssociativePCat
                         Graph)
    (seen 1 time)
  - couldn't build dictionary for constraint

AssociativePCat Graph

required by rassocP @Graph.
    - If the following errors refer to a missing instance (particularly for
     `HasRep`), it's likely that you need to define it.
      - <interactive>:1:1: error:
      No instance for (categorifier-unconcat-category-0.1:Categorifier.UnconCat.AssociativePCat
                         Graph)
    (seen 1 time)
  - couldn't build dictionary for constraint

Category Graph

required by id @Graph.
    - If the following errors refer to a missing instance (particularly for
     `HasRep`), it's likely that you need to define it.
      - <interactive>:1:1: error:
      No instance for (categorifier-unconcat-category-0.1:Categorifier.UnconCat.Category
                         Graph)
    (seen 1 time)
  - couldn't build dictionary for constraint

ClosedCat Graph

required by curry @Graph.
    - If the following errors refer to a missing instance (particularly for
     `HasRep`), it's likely that you need to define it.
      - <interactive>:1:1: error:
      No instance for (categorifier-unconcat-category-0.1:Categorifier.UnconCat.ClosedCat
                         Graph)
    (seen 1 time)
  - couldn't build dictionary for constraint

ClosedCat Graph

required by uncurry @Graph.
    - If the following errors refer to a missing instance (particularly for
     `HasRep`), it's likely that you need to define it.
      - <interactive>:1:1: error:
      No instance for (categorifier-unconcat-category-0.1:Categorifier.UnconCat.ClosedCat
                         Graph)
    (seen 1 time)
  - couldn't build dictionary for constraint

ProductCat Graph

required by exr @Graph.
    - If the following errors refer to a missing instance (particularly for
     `HasRep`), it's likely that you need to define it.
      - <interactive>:1:1: error:
      No instance for (categorifier-unconcat-category-0.1:Categorifier.UnconCat.ProductCat
                         Graph)
    (seen 1 time)

```